### PR TITLE
Add NoDisplay tag to not show up in applications menu

### DIFF
--- a/src/main/resources/assets/wayfix/com.mojang.minecraft.java-edition.desktop
+++ b/src/main/resources/assets/wayfix/com.mojang.minecraft.java-edition.desktop
@@ -2,8 +2,7 @@
 Name=Minecraft %s
 Comment=Explore your own unique world, survive the night, and create anything you can imagine!
 Icon=%s
-Exec=true
-Terminal=false
 Type=Application
+NoDisplay=true
 Categories=Game;
 %s


### PR DESCRIPTION
As the title says, this commit adds the "NoDisplay" tag to not show up in applications menu properly (I use GNOME)