### PR TITLE
fix(wayland): combine GLFW backend check with XDG_SESSION_TYPE detection

### DIFF
--- a/src/main/java/net/notcoded/wayfix/WayFix.java
+++ b/src/main/java/net/notcoded/wayfix/WayFix.java
@@ -10,6 +10,7 @@ import net.notcoded.wayfix.util.WindowHelper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.lwjgl.glfw.GLFW;
+import java.util.Objects;
 
 public class WayFix {
     public static final Logger LOGGER = LogManager.getLogger(WayFix.class);
@@ -35,7 +36,9 @@ public class WayFix {
 
     public static boolean supportsWayland() {
         try {
-            return GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND);
+            return GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND) &&
+                    Objects.requireNonNullElse(System.getenv("XDG_SESSION_TYPE"),
+                            "").toLowerCase().startsWith("wayland");
         } catch (NoSuchMethodError ignored) { // <3.3.0
             LOGGER.warn("WayFix is disabling itself due to the LWJGL Version being too low.");
             LOGGER.warn("Please update to a LWJGL version such as '3.3.1' or higher.");


### PR DESCRIPTION
The previous check using `glfwPlatformSupported` was insufficient as it only tests compilation support, not the active session type. This caused false positives on systems with Wayland-enabled GLFW libraries on X11 sessions.

Now also verify the XDG_SESSION_TYPE environment variable to ensure an actual Wayland session is active, preventing the crash on x11.

Fix: #73