### PR TITLE
Fix CWB borderless compat and fractional scaling click offset

### DIFF
--- a/src/main/java/net/notcoded/wayfix/mixin/MonitorFixWindowMixin.java
+++ b/src/main/java/net/notcoded/wayfix/mixin/MonitorFixWindowMixin.java
@@ -16,13 +16,16 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import static net.notcoded.wayfix.WayFix.isWayland;
+
 import java.util.ArrayList;
 import java.util.Collections;
 
-@Mixin(Window.class)
+@Mixin(value = Window.class, priority = 500)
 public abstract class MonitorFixWindowMixin {
 
     @Shadow protected abstract void onWindowPosChanged(long window, int x, int y);
+    @Shadow protected abstract void onWindowSizeChanged(long window, int width, int height);
 
     @Shadow @Final private long handle;
 
@@ -50,8 +53,6 @@ public abstract class MonitorFixWindowMixin {
             }
         }
 
-
-
         if(monitorID <= 0 || instance.getMonitor(monitorID) == null) {
             WayFix.LOGGER.warn("Error occurred while trying to set monitor.");
             WayFix.LOGGER.warn("Using primary monitor instead.");
@@ -60,7 +61,6 @@ public abstract class MonitorFixWindowMixin {
 
         return instance.getMonitor(monitorID);
     }
-
 
     // KDE Plasma ONLY
     @Inject(method = "updateWindowRegion", at = @At("HEAD"))
@@ -71,5 +71,22 @@ public abstract class MonitorFixWindowMixin {
         if(pos == null) return;
 
         onWindowPosChanged(this.handle, pos[0], pos[1]);
+    }
+
+    // Wayland fractional scaling fix: MC and mods (e.g. CWB) write physical monitor
+    // dimensions to window.width/height, but GLFW cursor coords use logical (surface)
+    // coords. Reconcile every frame by querying GLFW for the actual logical size.
+    @Inject(method = "swapBuffers", at = @At("HEAD"))
+    private void wayfix$reconcileWindowSize(CallbackInfo ci) {
+        if (!isWayland()) return;
+
+        int[] w = new int[1];
+        int[] h = new int[1];
+        GLFW.glfwGetWindowSize(this.handle, w, h);
+
+        Window self = (Window)(Object)this;
+        if (w[0] > 0 && h[0] > 0 && (self.getWidth() != w[0] || self.getHeight() != h[0])) {
+            onWindowSizeChanged(this.handle, w[0], h[0]);
+        }
     }
 }


### PR DESCRIPTION
Fixes two issues I ran into on Wayland with fractional scaling + Cubes Without Borders:

**Borderless always targeting the primary monitor**: CWB's cancellable HEAD inject on `updateWindowRegion` runs before WayFix's, so the kdotool correction never happens. Setting priority to 500 fixes the ordering. Borderless now fullscreens on the correct monitor with CWB.

**Click offset after fullscreen transitions**: on fractional scaling (tested 1.75x), MC writes physical dimensions (2560x1440) to window.width/height but GLFW cursor coords are in logical space (1463x823). Clicks land in the wrong place until you manually resize. The fix queries glfwGetWindowSize each frame in swapBuffers and corrects when they diverge.

Both are common complaints for anyone running Wayland + KDE + multi-monitor + fractional scaling. Tested on MC 1.21.11, Plasma 6.3.6, NVIDIA, CWB 3.0.0-build.14.

Side note: the README currently links BoyOrigin/glfw-wayland for the custom GLFW, but that repo crashes on newer MC versions and hasn't been updated for LWJGL-CI's fork. I maintain an updated patchset based on LWJGL-CI/glfw that works on 1.21.11+ here: https://github.com/jdkeke142/glfw-wayland-minecraft (fixes the windowed blur from glfw#2713, cursor-shape-v1, glfwSetCursorPos fallback for KDE <6.5, etc). Might be worth pointing users there.